### PR TITLE
Fix unifi-parental service install step.

### DIFF
--- a/cloudkey/README.md
+++ b/cloudkey/README.md
@@ -50,8 +50,10 @@ ln -s /usr/local/src/unifi-parental/cloudkey/nginx/unifi-parental /etc/nginx/sit
 ln -s /etc/nginx/sites-available/unifi-parental /etc/nginx/sites-enabled/
 ```
 5. Install unifi-parental service
+
+Note: Step 5 uses a **hard link** rather than a **symbolic link** - Systemd services *cannot* be symlinks.
 ```
-ln -s /usr/local/src/unifi-parental/cloudkey/unifi-parental.service /lib/systemd/system/
+ln /usr/local/src/unifi-parental/cloudkey/unifi-parental.service /lib/systemd/system/
 systemctl enable unifi-parental
 ```
 6. Start unifi-parental service


### PR DESCRIPTION
Systemd services cannot be symlinks, changed to a hardlink.

Sorry for missing this in https://github.com/tdack/unifi-parental/pull/6

Paul